### PR TITLE
foreignKey Array, skip DB query if the array is empty

### DIFF
--- a/views/create-resolvers-ddm.ejs
+++ b/views/create-resolvers-ddm.ejs
@@ -46,9 +46,9 @@ const associationArgsDef = {
             "value": this.<%= associations_one[i].targetKey -%>,
             "operator": "eq"
           });
-          let found = await resolvers.<%=associations_one[i].target_lc_pl%>Connection({search: nsearch,  pagination: {first:1}}, context);
-          if (found) {
-            return found[0]
+          let found = (await resolvers.<%=associations_one[i].target_lc_pl%>Connection({search: nsearch,  pagination: {first:1}}, context)).edges;
+          if (found.length > 0) {
+            return found[0].node
           }
           return found;
         }
@@ -90,7 +90,10 @@ const associationArgsDef = {
    <%- nameLc -%>.prototype.countFiltered<%=associations_temp[i].name_cp%> = function({search}, context){
 
      <%if(associations_temp[i].assocThroughArray){%>
-
+        //return 0 if the foreignKey Array is empty, no need to query the database
+        if (!Array.isArray(this.<%=associations_temp[i].sourceKey%>) || this.<%=associations_temp[i].sourceKey%>.length === 0 ) {
+          return 0;
+        }
          let nsearch = helper.addSearchField({
            "search": search,
            "field": models.<%=associations_temp[i].target_lc-%>.idAttribute(),
@@ -124,6 +127,18 @@ const associationArgsDef = {
    */
    <%- nameLc -%>.prototype.<%=associations_temp[i].name%>Connection = function({search,order,pagination}, context){
      <%if(associations_temp[i].assocThroughArray){%>
+        //return an empty response if the foreignKey Array is empty, no need to query the database
+        if (!Array.isArray(this.<%=associations_temp[i].sourceKey%>) || this.<%=associations_temp[i].sourceKey%>.length === 0 ) {
+          return {
+            edges: [],
+            pageInfo: {
+                startCursor: null,
+                endCursor: null,
+                hasPreviousPage: false,
+                hasNextPage: false
+            }
+          };
+        }
          let nsearch = helper.addSearchField({
            "search": search,
            "field": models.<%=associations_temp[i].target_lc-%>.idAttribute(),

--- a/views/create-resolvers.ejs
+++ b/views/create-resolvers.ejs
@@ -161,9 +161,9 @@ const associationArgsDef = {
             "value": this.<%= associations_one[i].targetKey -%>,
             "operator": "eq"
           });
-          let found = await resolvers.<%=associations_one[i].target_lc_pl%>({search: nsearch, pagination: {limit:1}}, context);
-          if (found) {
-            return found[0]
+          let found = (await resolvers.<%=associations_one[i].target_lc_pl%>Connection({search: nsearch,  pagination: {first:1}}, context)).edges;
+          if (found.length > 0) {
+            return found[0].node
           }
           return found;
         }
@@ -177,16 +177,16 @@ const associationArgsDef = {
           "operator": "eq"
         });
 
-        let found = await resolvers.<%=associations_one[i].target_lc_pl%>({search: nsearch, pagination: {limit:2}}, context);
-        if(found) {
+        let found = (await resolvers.<%=associations_one[i].target_lc_pl%>Connection({search: nsearch, pagination: {first:2}}, context)).edges;
+        if(found.length > 0) {
           if(found.length > 1){
             context.benignErrors.push(new Error(
               `Not unique "to_one" association Error: Found > 1 <%=associations_one[i].target_lc_pl%> matching <%- nameLc -%> with <%- idAttribute-%> ${this.getIdValue()}. Consider making this a "to_many" association, or using unique constraints, or moving the foreign key into the <%- name -%> model. Returning first <%=associations_one[i].target-%>.`
             ));
           }
-          return found[0];
+          return found[0].node;
         }
-        return found;
+        return null;
     <%}-%>
   }
 <%}-%>
@@ -221,6 +221,10 @@ const associationArgsDef = {
   <%- nameLc -%>.prototype.<%=associations_temp[i].name%>Filter = function({search,order,pagination}, context){
 
     <%if(associations_temp[i].assocThroughArray){%>
+        //return an empty response if the foreignKey Array is empty, no need to query the database
+        if (!Array.isArray(this.<%=associations_temp[i].sourceKey%>) || this.<%=associations_temp[i].sourceKey%>.length === 0 ) {
+          return [];
+        }
         let nsearch = helper.addSearchField({
           "search": search,
           "field": models.<%=associations_temp[i].target_lc-%>.idAttribute(),
@@ -252,6 +256,10 @@ const associationArgsDef = {
   <%- nameLc -%>.prototype.countFiltered<%=associations_temp[i].name_cp%> = function({search}, context){
 
     <%if(associations_temp[i].assocThroughArray){%>
+        //return 0 if the foreignKey Array is empty, no need to query the database
+        if (!Array.isArray(this.<%=associations_temp[i].sourceKey%>) || this.<%=associations_temp[i].sourceKey%>.length === 0 ) {
+          return 0;
+        }
         let nsearch = helper.addSearchField({
           "search": search,
           "field": models.<%=associations_temp[i].target_lc-%>.idAttribute(),
@@ -285,6 +293,18 @@ const associationArgsDef = {
   <%- nameLc -%>.prototype.<%=associations_temp[i].name%>Connection = function({search,order,pagination}, context){
 
     <%if(associations_temp[i].assocThroughArray){%>
+        //return an empty response if the foreignKey Array is empty, no need to query the database
+        if (!Array.isArray(this.<%=associations_temp[i].sourceKey%>) || this.<%=associations_temp[i].sourceKey%>.length === 0 ) {
+          return {
+            edges: [],
+            pageInfo: {
+                startCursor: null,
+                endCursor: null,
+                hasPreviousPage: false,
+                hasNextPage: false
+            }
+          };
+        }
         let nsearch = helper.addSearchField({
           "search": search,
           "field": models.<%=associations_temp[i].target_lc-%>.idAttribute(),


### PR DESCRIPTION
## issues

closes #176 

## Description

This PR fixes issue #176, as well as a correction to always use connection type fieldResolver.

The problem is that we use join to join the foreignKey Array. If the foreignKey array for a specific record is empty this results in an empty String '' . The query ... WHERE IN ('') however is faulty for Integers. The solution implemented is to skip the necessary queries (count and connection) in the respective field resolvers entirely, since we already know that there are no associated records, if the array is empty. Since the SPA tries to query the associated records and the pageInfo to display the correct content we need to return an empty dummy object for the connection query:
```
{
  edges:[],
  pageInfo: {
    startCursor: null,
    endCursor: null,
    hasNextPage: false,
    hasPreviousPage: false
  }
}
```

