### PR TITLE
refactor: only create model folder if a model of that storagetype exists

### DIFF
--- a/funks.js
+++ b/funks.js
@@ -1220,7 +1220,7 @@ module.exports.generateCode = async function (json_dir, dir_write, options) {
   //msg
   if (verbose)
     console.log(colors.white("\n@@ Creating required directories..."));
-  sectionsDirsA.concat(sectionsDirsB).forEach((section) => {
+  sectionsDirsA.forEach((section) => {
     let dir = dir_write + "/" + section;
     if (!fs.existsSync(dir)) {
       try {
@@ -1354,6 +1354,26 @@ module.exports.generateCode = async function (json_dir, dir_write, options) {
     //set sections
     let sections = []; //schemas, resolvers, models, migrations, validations, patches
     const migrationsDir = join("migrations", opts.database);
+
+    //Create models/<storageType> if it doesn't exist yet.
+    const storageDir = dir_write + "/models/" + opts.storageType;
+    if (!fs.existsSync(storageDir)) {
+      try {
+        fs.mkdirSync(storageDir);
+        //msg
+        if (verbose) console.log("@@@ dir created: ", colors.dim(storageDir));
+      } catch (e) {
+        //err
+        console.log(
+          colors.red("! mkdir.error: "),
+          "A problem occured while trying to create a required directory, please ensure you have the sufficient privileges to create directories and that you have a recent version of NodeJS"
+        );
+        console.log(colors.red("!@ mkdir.error: "), e);
+        console.log(colors.red("done"));
+        process.exit(1);
+      }
+    }
+
     switch (opts.storageType) {
       case "sql":
         sections = [

--- a/funks.js
+++ b/funks.js
@@ -1179,19 +1179,6 @@ module.exports.generateCode = async function (json_dir, dir_write, options) {
     "validations",
     "patches",
   ];
-  let sectionsDirsB = [
-    "models/sql",
-    "models/zendro-server",
-    "models/adapters",
-    "models/distributed",
-    "models/generic",
-    "models/cassandra",
-    "models/mongodb",
-    "models/amazonS3",
-    "models/trino",
-    "models/presto",
-    "models/neo4j",
-  ];
   let models = [];
   let adapters = [];
   let attributes_schema = {};


### PR DESCRIPTION
## Summary

Complementary PR to https://github.com/Zendro-dev/graphql-server/pull/72

## Changes
- only create model folder if a model of that storagetype exists. This reduces clutter in the models folder and the need to keep empty folders to start the graphql-server