### PR TITLE
Gis data types

### DIFF
--- a/funks.js
+++ b/funks.js
@@ -144,6 +144,15 @@ attributesToJsonSchemaProperties = function (attributes) {
     "[Date]",
     "[Time]",
     "[DateTime]",
+    "[Point]",
+    "[MultiPoint]",
+    "[LineString]",
+    "[MultiLineString]",
+    "[Polygon]",
+    "[MultiPolygon]",
+    "[GeometryCollection]",
+    "[Feature]",
+    "[FeatureCollection]"
   ];
 
   for (key in jsonSchemaProps) {
@@ -178,6 +187,38 @@ attributesToJsonSchemaProperties = function (attributes) {
     } else if (jsonSchemaProps[key] === "uuid") {
       jsonSchemaProps[key] = {
         type: ["uuid", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "Point") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "MultiPoint") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "LineString") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "MultiLineString") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "MultiPolygon") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "GeometryCollection") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "Feature") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
+    } else if (jsonSchemaProps[key] === "FeatureCollection") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
       };
     } else if (arrayType.includes(jsonSchemaProps[key])) {
       jsonSchemaProps[key] = {

--- a/funks.js
+++ b/funks.js
@@ -156,6 +156,18 @@ attributesToJsonSchemaProperties = function (attributes) {
     "[FeatureCollection]"
   ];
 
+  let gisTypes = [
+    "Point",
+    "MultiPoint",
+    "LineString",
+    "MultiLineString",
+    "Polygon",
+    "MultiPolygon",
+    "GeometryCollection",
+    "Feature",
+    "FeatureCollection"
+  ]
+
   for (key in jsonSchemaProps) {
     if (jsonSchemaProps[key] === "String") {
       jsonSchemaProps[key] = {
@@ -189,39 +201,7 @@ attributesToJsonSchemaProperties = function (attributes) {
       jsonSchemaProps[key] = {
         type: ["uuid", "null"],
       };
-    } else if (jsonSchemaProps[key] === "Point") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "MultiPoint") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "LineString") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "MultiLineString") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "Polygon") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "MultiPolygon") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "GeometryCollection") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "Feature") {
-      jsonSchemaProps[key] = {
-        type: ["object", "null"],
-      };
-    } else if (jsonSchemaProps[key] === "FeatureCollection") {
+    } else if (gisTypes.includes(jsonSchemaProps[key])) {
       jsonSchemaProps[key] = {
         type: ["object", "null"],
       };

--- a/funks.js
+++ b/funks.js
@@ -462,6 +462,15 @@ writeSchemaCommons = function (dir_write) {
   scalar Date
   scalar Time
   scalar DateTime
+  scalar Point
+  scalar MultiPoint
+  scalar LineString
+  scalar MultiLineString
+  scalar Polygon
+  scalar MultiPolygon
+  scalar GeometryCollection
+  scalar Feature
+  scalar FeatureCollection
 \`;`;
 
   try {

--- a/funks.js
+++ b/funks.js
@@ -204,6 +204,10 @@ attributesToJsonSchemaProperties = function (attributes) {
       jsonSchemaProps[key] = {
         type: ["object", "null"],
       };
+    } else if (jsonSchemaProps[key] === "Polygon") {
+      jsonSchemaProps[key] = {
+        type: ["object", "null"],
+      };
     } else if (jsonSchemaProps[key] === "MultiPolygon") {
       jsonSchemaProps[key] = {
         type: ["object", "null"],


### PR DESCRIPTION
## Summary
This PR adds support for gis data types for conversion of object attributes to JSON-Schema properties, and graphql scalars.

## Changes 
* add gis types in convertion to JSON-Schema properties function 
* add gis scalar for the graphql schema